### PR TITLE
Remove Kotlin standard library dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,8 +27,6 @@ repositories {
 }
 
 dependencies {
-    //Kotlin
-    implementation(kotlin("stdlib"))
 
     //Ktor
     implementation("io.ktor:ktor-server-cio:$ktorVersion")


### PR DESCRIPTION
Removed Kotlin standard library dependency from build.gradle.kts